### PR TITLE
Removes creating log links on Windows, closes #22

### DIFF
--- a/libraries/qsl/sl.q
+++ b/libraries/qsl/sl.q
@@ -339,10 +339,6 @@
   if[(string .z.o) like "l*";
     system "ln -f -s ",((1+count string hsym .log.path)_string .log.p.path)," ",1_(string hsym .log.path),"/current.log"
     ];
-  if[(string .z.o) like "w*";
-    system "erase /q ","\"",.sl.p.winsl (1_(string hsym .log.path),"\\current.log\"");
-    system "mklink ",.sl.p.winsl "\"",(1_(string hsym .log.path),"\\current.log\" "),(1+count string hsym .log.path)_string .log.p.path;
-    ];
   };
 
 /F/ Trims the .log.hist buffer, removing a given part of it, starting 


### PR DESCRIPTION
Removed creating and maintaining links to current and init log on Windows.
