### PR TITLE
fix - qsl/handle.q: failure of `lazy connection logged as warn (instead of error)

### DIFF
--- a/libraries/qsl/handle.q
+++ b/libraries/qsl/handle.q
@@ -230,7 +230,7 @@
 .hnd.p.errHlazy:{[s;e] 
   sig:"can't open connection to ",string[s],", error: ",e;
   .hnd.status[s;`state`msg]:(`failed;sig);
-  .log.error[`handle] sig;
+  .log.warn[`handle] sig;
   // start reconnection only when it is not running (user may call .hnd.h many times)
   if[not (tid:`$".hnd.rec.",.hnd.p.remdot s) in .tmr.status`funid;
     .tmr.start[tid;.hnd.timer;tid]


### PR DESCRIPTION
`lazy connection failure was logged as`error, should be logged as `warn instead.
`eager connection failure was always logged as `warn.
Now both`eager and `lazy connection failures are logged as warn.
