### PR TITLE
Fixes: eod storage in hdb of tables not having `sym column fails with `length error

### DIFF
--- a/components/rdb/rdb.q
+++ b/components/rdb/rdb.q
@@ -103,8 +103,8 @@ system"l ",getenv[`EC_QSL_PATH],"/sl.q";
   .rdb.date:.sl.eodSyncedDate[];
 
   //end of day
-  eodTabs:select table:sectionVal, hdbPath:eodPath, hdbName:hdbConn, memoryClear:eodClear, store:eodPerform from .rdb.cfg.eodTabs;
-  .event.dot[`rdb;`.store.init;(eodTabs;.rdb.cfg.reloadHdb;.rdb.cfg.fillMissingTabsHdb;.rdb.cfg.dataPath);();`debug`info`error;"initializing store library"];
+  config:select table:sectionVal, hdbPath:eodPath, hdbName:hdbConn, memoryClear:eodClear, store:eodPerform, attrCol from .rdb.cfg.eodTabs;
+  .event.dot[`rdb;`.store.init;(config;.rdb.cfg.reloadHdb;.rdb.cfg.fillMissingTabsHdb;.rdb.cfg.dataPath);();`debug`info`error;"initializing store library"];
 
   //connections
   hdb2conn:exec distinct hdbConn from .rdb.cfg.eodTabs where not hdbConn~'`;

--- a/components/rdb/rdb.qsd
+++ b/components/rdb/rdb.qsd
@@ -33,6 +33,8 @@
   #/C/ flag for performing eod
   #/E/ eodPerform = 1
   eodPerform = <type(BOOLEAN) default(1)>
+  #/E/ table column to partition by for dhb eod write
+  attrCol = <type(SYMBOL) default(sym)>
 [sysTable]
   #/C/ connection settings for hdb
   #/E/ hdbConn = kdb.hdb


### PR DESCRIPTION
`rdb` expects the column `'sym` to be available in every table (this is also a constraint of the `tickHF` so usually is not a problem).

When using the `dist` component instead of `tickHF` to publish to the `rdb`, tables **without** `'sym` column break the eod write to the `hdb` with a `'length error`.

The `.stor` library was prepared for that case and looks for a column `'attrCol` for customisation of the column the table gets partitioned by. 
The rdb does not provide that column by default, so every table automatically defaults back to `'sym`.

This PR fixes that issue and just enables you to pass the definition of the table, the `hdb` should partition by on eod in `dataflow.cfg`


    [table:Accounts]
        model = accountID(INT), name(STRING), email(STRING), date(TIMESTAMP)
        template = something
        [[core.rdb]]
          attrCol = date